### PR TITLE
Extension of import_mesh_from_xdmf()

### DIFF
--- a/msh2xdmf.py
+++ b/msh2xdmf.py
@@ -187,15 +187,15 @@ def import_mesh_from_xdmf(
         dim=2,
         directory=".",
         ):
-    """
-    Function importing a dolfin mesh.
+    """Function importing a dolfin mesh.
 
     Arguments:
-        - domain (str): name of the domain XDMF file;
-        - boundaries (str): name of the boundaries XDMF file;
-        - dim (int): dimension of the domain;
-        - subdomains (bool): true if there are subdomains, else false
-        - directory (str): (optional) directory of the mesh;
+        prefix (str, optional): mesh files prefix (eg. my_mesh.msh,
+            my_mesh_domain.xdmf, my_mesh_bondaries.xdmf). Defaults to "mesh".
+        subdomains (bool, optional): True if there are subdomains. Defaults to
+            False.
+        dim (int, optional): dimension of the domain. Defaults to 2.
+        directory (str, optional): directory of the mesh files. Defaults to ".".
 
     Output:
         - dolfin Mesh object containing the domain;

--- a/msh2xdmf.py
+++ b/msh2xdmf.py
@@ -210,7 +210,7 @@ def import_mesh_from_xdmf(
     # create 2 xdmf files if not converted before
     if not os.path.exists("{}/{}".format(directory, domain)) or \
        not os.path.exists("{}/{}".format(directory, boundaries)):
-        msh2xdmf(".msh".format(prefix), dim=dim, directory=".")
+        msh2xdmf("{}.msh".format(prefix), dim=dim, directory=directory)
 
     # Import the converted domain
     mesh = Mesh()

--- a/msh2xdmf.py
+++ b/msh2xdmf.py
@@ -206,6 +206,12 @@ def import_mesh_from_xdmf(
     # Set the file name
     domain = "{}_domain.xdmf".format(prefix)
     boundaries = "{}_boundaries.xdmf".format(prefix)
+
+    # create 2 xdmf files if not converted before
+    if not os.path.exists("{}/{}".format(directory, domain)) or \
+       not os.path.exists("{}/{}".format(directory, boundaries)):
+        msh2xdmf(".msh".format(prefix), dim=dim, directory=".")
+
     # Import the converted domain
     mesh = Mesh()
     with XDMFFile("{}/{}".format(directory, domain)) as infile:


### PR DESCRIPTION
This PR includes an extension of `import_mesh_from_xdmf()`.

The function now creates the XDMF files if they aren't found in the directory with the function `msh2xdmf()`.

This way, users don't have to run the terminal command `python 3 msh2xdmf.py mesh.msh` beforehand and can simply run `import_mesh_from_xdmf('mesh')` in their dolfin script.